### PR TITLE
🍕 Add release workflow + cross-platform zip helper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+# Triggered when a `vX.Y.Z` tag is pushed (the standard `npm version` flow),
+# or manually via the Actions tab against an existing tag.
+#
+# What it does:
+#   1. Verifies the tag matches `package.json`'s version (fails fast otherwise).
+#   2. Runs the full validation suite (typecheck / lint / format / test).
+#   3. Builds the extension into `dist/`.
+#   4. Zips `dist/` as `clay-slip-vX.Y.Z.zip` (Chrome Web Store-ready).
+#   5. Creates a *draft* GitHub release with the zip attached and auto-
+#      generated release notes. A human reviews and publishes it.
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v2.1.0). Must already exist on the repo.'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event.inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build, package, and draft release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (at the release tag)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Resolve tag and version
+        id: meta
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error title=Version mismatch::Tag $TAG does not match package.json version $PKG_VERSION. Bump package.json and re-tag."
+            exit 1
+          fi
+          ZIP="clay-slip-${TAG}.zip"
+          echo "tag=$TAG"          >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION"  >> "$GITHUB_OUTPUT"
+          echo "zip=$ZIP"          >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate (typecheck / lint / format / test)
+        run: npm run validate
+
+      - name: Build
+        run: npm run build
+
+      - name: Package extension
+        run: |
+          cd dist
+          zip -r "../${{ steps.meta.outputs.zip }}" .
+          cd ..
+          ls -lh "${{ steps.meta.outputs.zip }}"
+
+      - name: Upload zip as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.zip }}
+          path: ${{ steps.meta.outputs.zip }}
+          retention-days: 30
+
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.meta.outputs.tag }}" \
+            "${{ steps.meta.outputs.zip }}" \
+            --draft \
+            --generate-notes \
+            --title "Clay Slip ${{ steps.meta.outputs.tag }}"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 .env
 .env.local
 .eslintcache
+clay-slip-v*.zip

--- a/README.md
+++ b/README.md
@@ -141,19 +141,47 @@ src/
 
 ## Scripts
 
-| Command                 | What it does                            |
-| ----------------------- | --------------------------------------- |
-| `npm run dev`           | Vite dev server with HMR                |
-| `npm run build`         | Typecheck + production build → `dist/`  |
-| `npm run lint`          | ESLint with zero-warning policy         |
-| `npm run lint:fix`      | ESLint auto-fix                         |
-| `npm run format`        | Prettier write                          |
-| `npm run format:check`  | Prettier check (used in CI)             |
-| `npm run test`          | Run Vitest                              |
-| `npm run test:watch`    | Vitest in watch mode                    |
-| `npm run test:coverage` | Vitest with coverage                    |
-| `npm run typecheck`     | `tsc --noEmit`                          |
-| `npm run validate`      | Typecheck + lint + format check + tests |
+| Command                 | What it does                             |
+| ----------------------- | ---------------------------------------- |
+| `npm run dev`           | Vite dev server with HMR                 |
+| `npm run build`         | Typecheck + production build → `dist/`   |
+| `npm run lint`          | ESLint with zero-warning policy          |
+| `npm run lint:fix`      | ESLint auto-fix                          |
+| `npm run format`        | Prettier write                           |
+| `npm run format:check`  | Prettier check (used in CI)              |
+| `npm run test`          | Run Vitest                               |
+| `npm run test:watch`    | Vitest in watch mode                     |
+| `npm run test:coverage` | Vitest with coverage                     |
+| `npm run typecheck`     | `tsc --noEmit`                           |
+| `npm run validate`      | Typecheck + lint + format check + tests  |
+| `npm run zip`           | Pack `dist/` into `clay-slip-vX.Y.Z.zip` |
+| `npm run release:dry`   | Validate + build + zip (mirrors CI)      |
+
+## Releasing
+
+Releases are automated by `.github/workflows/release.yml`. The flow is:
+
+1. Bump the version + create a tag locally:
+
+   ```sh
+   npm version patch         # or `minor` / `major`
+   git push --follow-tags
+   ```
+
+   `npm version` updates `package.json`, commits, and creates an annotated `vX.Y.Z` tag in one shot.
+
+2. The push of the tag triggers the **Release** workflow, which:
+   - Verifies the tag matches `package.json` (fails fast on mismatch).
+   - Runs the full validation suite (typecheck / lint / format / test).
+   - Builds the extension.
+   - Zips `dist/` as `clay-slip-vX.Y.Z.zip`.
+   - Creates a **draft** GitHub release with the zip attached and auto-generated release notes.
+
+3. Open the draft release on GitHub, edit the notes, and **Publish**.
+
+4. Upload the zip to the [Chrome Web Store dashboard](https://chrome.google.com/webstore/devconsole) → _New version_.
+
+You can also kick off the workflow manually from the Actions tab against an existing tag (useful if a release run fails midway). Want to package locally without going through CI? `npm run release:dry` produces an identical `clay-slip-vX.Y.Z.zip` next to the repo.
 
 ## Migration notes (1.0 → 2.0)
 
@@ -164,7 +192,7 @@ This release is a full rewrite. There are no breaking _features_ — every capab
 - **Vanilla JS → TypeScript 6 + React 19**: the panel UI is React inside a Shadow DOM, with strict typing.
 - **Build system**: `npm` + **Vite 8** + `@crxjs/vite-plugin` for HMR-friendly extension development.
 - **State**: **Zustand 5** for the panel store.
-- **Testing**: **Vitest 4** + happy-dom 20; 85 tests.
+- **Testing**: **Vitest 4** + happy-dom 20; 84 tests.
 - **Lint / format**: ESLint 9 flat config + `typescript-eslint@8` + Prettier 3.
 - **CI**: GitHub Actions runs typecheck, lint, format check, tests, and a production build on every push and PR.
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit",
-    "validate": "npm run typecheck && npm run lint && npm run format:check && npm run test"
+    "validate": "npm run typecheck && npm run lint && npm run format:check && npm run test",
+    "zip": "node scripts/zip-extension.mjs",
+    "release:dry": "npm run validate && npm run build && npm run zip"
   },
   "dependencies": {
     "react": "^19.2.6",

--- a/scripts/zip-extension.mjs
+++ b/scripts/zip-extension.mjs
@@ -1,0 +1,59 @@
+// Pack the built `dist/` directory into `clay-slip-vX.Y.Z.zip`, ready to
+// upload to the Chrome Web Store dashboard or to share for sideloading.
+//
+//   npm run zip            (assumes `dist/` already exists)
+//   npm run release:dry    (validate + build + zip in one shot)
+//
+// Cross-platform: shells out to `zip` on macOS/Linux and PowerShell's
+// `Compress-Archive` on Windows. Either is preinstalled on a clean dev box.
+
+import { spawn } from 'node:child_process';
+import { existsSync, statSync, rmSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const distDir = join(root, 'dist');
+const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+const outName = `clay-slip-v${pkg.version}.zip`;
+const outPath = join(root, outName);
+
+if (!existsSync(distDir) || !statSync(distDir).isDirectory()) {
+  console.error(`✖ ${distDir} not found. Run \`npm run build\` first.`);
+  process.exit(1);
+}
+
+if (existsSync(outPath)) {
+  rmSync(outPath);
+}
+
+const isWindows = process.platform === 'win32';
+
+const cmd = isWindows ? 'powershell.exe' : 'zip';
+const args = isWindows
+  ? [
+      '-NoProfile',
+      '-Command',
+      `Compress-Archive -Path 'dist/*' -DestinationPath '${outName}' -Force`,
+    ]
+  : ['-r', outPath, '.'];
+
+const cwd = isWindows ? root : distDir;
+
+const child = spawn(cmd, args, { cwd, stdio: 'inherit' });
+
+child.on('error', (err) => {
+  console.error(`✖ Failed to launch packager: ${err.message}`);
+  if (!isWindows) console.error('  Make sure the `zip` command is installed (it ships with macOS/most distros).');
+  process.exit(1);
+});
+
+child.on('exit', (code) => {
+  if (code !== 0) {
+    console.error(`✖ Packager exited with code ${code}`);
+    process.exit(code ?? 1);
+  }
+  const size = (statSync(outPath).size / 1024).toFixed(1);
+  console.log(`✓ wrote ${outName} (${size} KB)`);
+});


### PR DESCRIPTION
## Summary

Adds a one-tag-push release pipeline so cutting a Chrome Web Store-ready build is automatic.

- **`.github/workflows/release.yml`** — triggered by a `vX.Y.Z` tag (or manual dispatch from the Actions tab against an existing tag). It:
  1. Verifies the tag matches `package.json`'s version (fails fast on mismatch).
  2. Runs the full validation suite (typecheck / lint / format / test).
  3. Builds the extension into `dist/`.
  4. Zips `dist/` as `clay-slip-vX.Y.Z.zip` and uploads it as a workflow artifact.
  5. Creates a **draft** GitHub release with the zip attached and auto-generated release notes (from PRs since the last release). A human edits + publishes.

- **`scripts/zip-extension.mjs` + `npm run zip`** — cross-platform local packager (`zip` on Unix, PowerShell `Compress-Archive` on Windows). Pairs with `npm run release:dry`, which mirrors CI end to end (`validate && build && zip`).

- **`.gitignore`** ignores `clay-slip-v*.zip` so accidental local packs don't get tracked.

- **README** gains a "Releasing" section documenting the `npm version patch && git push --follow-tags` flow and how to upload to the Chrome Web Store from the resulting draft.

## How to release after this lands

```sh
npm version patch         # or `minor` / `major` — bumps package.json + tags vX.Y.Z
git push --follow-tags    # triggers the Release workflow

# → workflow runs → draft release appears in the Releases tab
# → review + publish → upload the attached zip to the Chrome Web Store dashboard
```

## Test plan

- [x] `npm run validate` passes (typecheck / lint / format / test — 84 tests)
- [x] `npm run release:dry` ran end to end locally and produced a 332.8 KB `clay-slip-v2.0.0.zip`
- [x] CI on this PR (validates the workflow file is syntactically valid and the rest of the codebase still builds)
- [ ] Once merged: cut a `v2.0.1` (or whatever) tag and confirm the Release workflow runs green and produces a draft release

Made with [Cursor](https://cursor.com)