### PR TITLE
🍕 fix(manifest): trim description to 121 chars + add build-time guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clay-slip",
   "version": "2.0.2",
-  "description": "A modern Chrome extension for exploring Clay CMS pages — visualize component boundaries, inspect data, and navigate the page/layout hierarchy.",
+  "description": "Modern devtools for Clay CMS pages: visualize component boundaries, inspect data, and navigate the page/layout hierarchy.",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,6 +1,16 @@
 import { defineManifest } from '@crxjs/vite-plugin';
 import pkg from '../package.json' with { type: 'json' };
 
+// Chrome Web Store rejects uploads with `manifest.description` > 132 chars.
+// Catch the regression at build time, where it's easy to fix, instead of at
+// upload time, where it bricks a release.
+const MAX_DESCRIPTION_CHARS = 132;
+if (pkg.description.length > MAX_DESCRIPTION_CHARS) {
+  throw new Error(
+    `package.json "description" is ${pkg.description.length} chars; Chrome Web Store limit is ${MAX_DESCRIPTION_CHARS}.`
+  );
+}
+
 export default defineManifest({
   manifest_version: 3,
   name: 'Clay Slip',


### PR DESCRIPTION
## Summary

Resolves the Chrome Web Store upload rejection:

> The description field in manifest is too long: 142. It exceeds maximum size limit of 132 characters.

The store caps `manifest.description` at **132 chars**. Ours was 142.

## Changes

### 1. Trim the description (142 → 121 chars)

| | Description | Length |
|---|---|---|
| Before | `A modern Chrome extension for exploring Clay CMS pages — visualize component boundaries, inspect data, and navigate the page/layout hierarchy.` | 142 ❌ |
| After  | `Modern devtools for Clay CMS pages: visualize component boundaries, inspect data, and navigate the page/layout hierarchy.` | **121 ✅** |

11 chars under the limit; meaning preserved.

### 2. Build-time guard in `src/manifest.ts`

```ts
const MAX_DESCRIPTION_CHARS = 132;
if (pkg.description.length > MAX_DESCRIPTION_CHARS) {
  throw new Error(
    `package.json "description" is ${pkg.description.length} chars; Chrome Web Store limit is ${MAX_DESCRIPTION_CHARS}.`
  );
}
```

Vite imports `src/manifest.ts` during build, so this throws at `npm run build` time (and therefore in CI) the moment anyone bumps the description past 132 chars. We never get into an upload-rejection loop again.

### 3. No version bump

The previous v2.0.2 upload was rejected by the store and never recorded, so 2.0.2 is still an available slot. No need to burn a patch number on this.

## Verification

```
$ unzip -p clay-slip-v2.0.2.zip manifest.json | jq -r '.description | length'
121
```

- [x] `npm run validate` (84 tests, lint, format, typecheck) — passes
- [x] `npm run build` — builds, manifest description is 121 chars
- [x] `npm run zip` — produces a 101 KB `clay-slip-v2.0.2.zip` with the fixed manifest
- [ ] After merge: re-upload to Chrome Web Store dashboard (should be accepted)

## Test plan

- [x] Locally rebuilt and verified the manifest in the zip
- [x] Deliberately set the description to 200 chars and confirmed `npm run build` fails with the expected error message
- [ ] CI on this PR (greens the same build path)

Made with [Cursor](https://cursor.com)