### PR TITLE
🍕 feat(seo): collapsible JSON-LD viewer + inline validator

### DIFF
--- a/src/content/panel/components/JsonPreview.tsx
+++ b/src/content/panel/components/JsonPreview.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { buildUrl } from '@/lib/clay-uri';
 import { copyToClipboard } from '@/lib/clipboard';
+import { highlightJson } from '@/lib/json-highlight';
 import { useEnvHost, useStore } from '../store';
 import { Icon } from './Icon';
 
@@ -11,32 +12,6 @@ interface FetchState {
 }
 
 const cache = new Map<string, FetchState>();
-
-function highlightJson(value: unknown): string {
-  const json = JSON.stringify(value, null, 2);
-  return json
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(
-      /("(\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*"(?=\s*:))|("(\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*")|(\b(?:true|false)\b)|(\bnull\b)|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g,
-      (match: string) => {
-        if (/^"[^"]+"\s*:?$/.test(match) && match.endsWith(':')) {
-          return `<span class="cs-json-key">${match}</span>`;
-        }
-        if (match.startsWith('"')) {
-          return `<span class="cs-json-string">${match}</span>`;
-        }
-        if (match === 'true' || match === 'false') {
-          return `<span class="cs-json-bool">${match}</span>`;
-        }
-        if (match === 'null') {
-          return `<span class="cs-json-null">${match}</span>`;
-        }
-        return `<span class="cs-json-number">${match}</span>`;
-      }
-    );
-}
 
 function cacheKey(uri: string | null, host: string): string {
   return `${host || '_'}::${uri ?? ''}`;

--- a/src/content/panel/components/SeoTab.tsx
+++ b/src/content/panel/components/SeoTab.tsx
@@ -1,7 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { copyToClipboard } from '@/lib/clipboard';
 import { highlightJson } from '@/lib/json-highlight';
-import { extractSeoMeta, lintSeo, summarizeJsonLd, type SeoIssue, type SeoMeta } from '@/lib/seo';
+import {
+  extractSeoMeta,
+  lintJsonLd,
+  lintSeo,
+  summarizeJsonLd,
+  type JsonLdIssue,
+  type SeoIssue,
+  type SeoMeta,
+} from '@/lib/seo';
 import { useStore } from '../store';
 import { Icon } from './Icon';
 
@@ -10,6 +18,20 @@ const TONE: Record<SeoIssue['severity'], string> = {
   warn: 'cs-seo-issue-warn',
   info: 'cs-seo-issue-info',
 };
+
+const SEVERITY_RANK: Record<SeoIssue['severity'], number> = { error: 0, warn: 1, info: 2 };
+
+/** Pick the most important severity from a list of issues. */
+function worstSeverity(
+  issues: readonly { severity: SeoIssue['severity'] }[]
+): SeoIssue['severity'] | null {
+  if (issues.length === 0) return null;
+  return issues.reduce<SeoIssue['severity']>(
+    (worst, issue) =>
+      SEVERITY_RANK[issue.severity] < SEVERITY_RANK[worst] ? issue.severity : worst,
+    'info'
+  );
+}
 
 function CardPreview({ meta, kind }: { meta: SeoMeta; kind: 'twitter' | 'facebook' }) {
   const title =
@@ -45,10 +67,22 @@ function CardPreview({ meta, kind }: { meta: SeoMeta; kind: 'twitter' | 'faceboo
   );
 }
 
-function JsonLdBlockCard({ block, index }: { block: unknown; index: number }) {
+function JsonLdBlockCard({
+  block,
+  index,
+  issues,
+}: {
+  block: unknown;
+  index: number;
+  issues: readonly JsonLdIssue[];
+}) {
   const pushToast = useStore((s) => s.pushToast);
-  const [open, setOpen] = useState(false);
+  // Open by default if the block has any errors so the user immediately
+  // sees what's wrong without an extra click.
+  const hasError = issues.some((i) => i.severity === 'error');
+  const [open, setOpen] = useState(hasError);
   const summary = summarizeJsonLd(block);
+  const headerSeverity = worstSeverity(issues);
 
   const onCopy = async (e: React.MouseEvent) => {
     // Prevent the click from toggling the <details> open state.
@@ -60,9 +94,14 @@ function JsonLdBlockCard({ block, index }: { block: unknown; index: number }) {
     pushToast(ok ? `Copied JSON-LD block #${index + 1}` : 'Copy failed', ok ? 'success' : 'error');
   };
 
+  const cardClasses = ['cs-jsonld-card'];
+  if (summary.invalid) cardClasses.push('cs-jsonld-card-invalid');
+  if (headerSeverity === 'error') cardClasses.push('cs-jsonld-card-has-error');
+  else if (headerSeverity === 'warn') cardClasses.push('cs-jsonld-card-has-warn');
+
   return (
     <details
-      className={`cs-jsonld-card${summary.invalid ? ' cs-jsonld-card-invalid' : ''}`}
+      className={cardClasses.join(' ')}
       open={open}
       onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}
     >
@@ -85,6 +124,15 @@ function JsonLdBlockCard({ block, index }: { block: unknown; index: number }) {
             {summary.secondary}
           </span>
         )}
+        {issues.length > 0 && (
+          <span
+            className={`cs-jsonld-badge cs-jsonld-badge-${headerSeverity}`}
+            title={`${issues.length} ${headerSeverity === 'error' ? 'error' : headerSeverity === 'warn' ? 'warning' : 'note'}${issues.length === 1 ? '' : 's'}`}
+          >
+            {headerSeverity === 'error' ? '✕' : headerSeverity === 'warn' ? '!' : 'i'}{' '}
+            {issues.length}
+          </span>
+        )}
         <button
           type="button"
           className="cs-icon-btn cs-jsonld-copy"
@@ -97,20 +145,40 @@ function JsonLdBlockCard({ block, index }: { block: unknown; index: number }) {
       </summary>
       {/* Body is only mounted once expanded — saves the syntax-highlight
           regex pass on big @graph payloads when the user never opens them. */}
-      {open &&
-        (summary.invalid && isInvalidBlock(block) ? (
-          <div className="cs-jsonld-body">
-            <p className="cs-jsonld-error">
-              This block isn&rsquo;t valid JSON. Showing the raw script contents:
-            </p>
-            <pre className="cs-jsonld-raw">{block.raw ?? '(empty)'}</pre>
-          </div>
-        ) : (
-          <pre
-            className="cs-json cs-jsonld-body"
-            dangerouslySetInnerHTML={{ __html: highlightJson(block) }}
-          />
-        ))}
+      {open && (
+        <>
+          {issues.length > 0 && (
+            <ul className="cs-jsonld-issues">
+              {issues.map((issue, i) => (
+                <li key={`${issue.code}-${i}`} className={`cs-seo-issue ${TONE[issue.severity]}`}>
+                  <span className="cs-seo-issue-tag">{issue.severity}</span>
+                  <span className="cs-jsonld-issue-body">
+                    {issue.message}
+                    {issue.path && (
+                      <code className="cs-jsonld-issue-path" title={issue.path}>
+                        {issue.path}
+                      </code>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {summary.invalid && isInvalidBlock(block) ? (
+            <div className="cs-jsonld-body">
+              <p className="cs-jsonld-error">
+                This block isn&rsquo;t valid JSON. Showing the raw script contents:
+              </p>
+              <pre className="cs-jsonld-raw">{block.raw ?? '(empty)'}</pre>
+            </div>
+          ) : (
+            <pre
+              className="cs-json cs-jsonld-body"
+              dangerouslySetInnerHTML={{ __html: highlightJson(block) }}
+            />
+          )}
+        </>
+      )}
     </details>
   );
 }
@@ -124,18 +192,49 @@ function isInvalidBlock(block: unknown): block is { __invalid: true; raw: string
 }
 
 function JsonLdSection({ blocks }: { blocks: readonly unknown[] }) {
+  // Lint once at the section level and group by blockIndex so each card
+  // only re-renders when its own slice of issues changes. Issues for the
+  // duplicate-@id check (which span multiple blocks) attach to the
+  // earliest block by design — see lintJsonLd.
+  const issuesByBlock = useMemo(() => {
+    const all = lintJsonLd(blocks);
+    const map = new Map<number, JsonLdIssue[]>();
+    for (const issue of all) {
+      const list = map.get(issue.blockIndex) ?? [];
+      list.push(issue);
+      map.set(issue.blockIndex, list);
+    }
+    return map;
+  }, [blocks]);
+
   if (blocks.length === 0) return null;
+
+  const errorCount = [...issuesByBlock.values()]
+    .flat()
+    .filter((i) => i.severity === 'error').length;
+  const warnCount = [...issuesByBlock.values()].flat().filter((i) => i.severity === 'warn').length;
+
   return (
     <section className="cs-section">
       <h4 className="cs-section-title">
         Structured data (JSON-LD){' '}
         <span className="cs-section-count">
           · {blocks.length} block{blocks.length === 1 ? '' : 's'}
+          {errorCount > 0 && (
+            <span className="cs-jsonld-badge cs-jsonld-badge-error cs-jsonld-badge-inline">
+              ✕ {errorCount} error{errorCount === 1 ? '' : 's'}
+            </span>
+          )}
+          {warnCount > 0 && (
+            <span className="cs-jsonld-badge cs-jsonld-badge-warn cs-jsonld-badge-inline">
+              ! {warnCount} warning{warnCount === 1 ? '' : 's'}
+            </span>
+          )}
         </span>
       </h4>
       <div className="cs-jsonld-list">
         {blocks.map((block, i) => (
-          <JsonLdBlockCard key={i} block={block} index={i} />
+          <JsonLdBlockCard key={i} block={block} index={i} issues={issuesByBlock.get(i) ?? []} />
         ))}
       </div>
     </section>

--- a/src/content/panel/components/SeoTab.tsx
+++ b/src/content/panel/components/SeoTab.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react';
-import { extractSeoMeta, lintSeo, type SeoIssue, type SeoMeta } from '@/lib/seo';
+import { copyToClipboard } from '@/lib/clipboard';
+import { highlightJson } from '@/lib/json-highlight';
+import { extractSeoMeta, lintSeo, summarizeJsonLd, type SeoIssue, type SeoMeta } from '@/lib/seo';
+import { useStore } from '../store';
+import { Icon } from './Icon';
 
 const TONE: Record<SeoIssue['severity'], string> = {
   error: 'cs-seo-issue-error',
@@ -38,6 +42,103 @@ function CardPreview({ meta, kind }: { meta: SeoMeta; kind: 'twitter' | 'faceboo
         <p className="cs-seo-card-desc">{description || 'No description set.'}</p>
       </div>
     </div>
+  );
+}
+
+function JsonLdBlockCard({ block, index }: { block: unknown; index: number }) {
+  const pushToast = useStore((s) => s.pushToast);
+  const [open, setOpen] = useState(false);
+  const summary = summarizeJsonLd(block);
+
+  const onCopy = async (e: React.MouseEvent) => {
+    // Prevent the click from toggling the <details> open state.
+    e.preventDefault();
+    e.stopPropagation();
+    const text =
+      summary.invalid && isInvalidBlock(block) ? (block.raw ?? '') : JSON.stringify(block, null, 2);
+    const ok = await copyToClipboard(text);
+    pushToast(ok ? `Copied JSON-LD block #${index + 1}` : 'Copy failed', ok ? 'success' : 'error');
+  };
+
+  return (
+    <details
+      className={`cs-jsonld-card${summary.invalid ? ' cs-jsonld-card-invalid' : ''}`}
+      open={open}
+      onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}
+    >
+      <summary className="cs-jsonld-summary">
+        <span className="cs-jsonld-chevron" aria-hidden="true">
+          ▶
+        </span>
+        <span className="cs-jsonld-index">#{index + 1}</span>
+        <span className="cs-jsonld-type" title={summary.typeLabel}>
+          {summary.typeLabel}
+          {summary.itemCount !== null && (
+            <span className="cs-jsonld-count">
+              {' '}
+              · {summary.itemCount} item{summary.itemCount === 1 ? '' : 's'}
+            </span>
+          )}
+        </span>
+        {summary.secondary && (
+          <span className="cs-jsonld-secondary" title={summary.secondary}>
+            {summary.secondary}
+          </span>
+        )}
+        <button
+          type="button"
+          className="cs-icon-btn cs-jsonld-copy"
+          onClick={onCopy}
+          aria-label={`Copy JSON-LD block ${index + 1}`}
+          title="Copy JSON to clipboard"
+        >
+          <Icon name="copy" />
+        </button>
+      </summary>
+      {/* Body is only mounted once expanded — saves the syntax-highlight
+          regex pass on big @graph payloads when the user never opens them. */}
+      {open &&
+        (summary.invalid && isInvalidBlock(block) ? (
+          <div className="cs-jsonld-body">
+            <p className="cs-jsonld-error">
+              This block isn&rsquo;t valid JSON. Showing the raw script contents:
+            </p>
+            <pre className="cs-jsonld-raw">{block.raw ?? '(empty)'}</pre>
+          </div>
+        ) : (
+          <pre
+            className="cs-json cs-jsonld-body"
+            dangerouslySetInnerHTML={{ __html: highlightJson(block) }}
+          />
+        ))}
+    </details>
+  );
+}
+
+function isInvalidBlock(block: unknown): block is { __invalid: true; raw: string | null } {
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    (block as { __invalid?: unknown }).__invalid === true
+  );
+}
+
+function JsonLdSection({ blocks }: { blocks: readonly unknown[] }) {
+  if (blocks.length === 0) return null;
+  return (
+    <section className="cs-section">
+      <h4 className="cs-section-title">
+        Structured data (JSON-LD){' '}
+        <span className="cs-section-count">
+          · {blocks.length} block{blocks.length === 1 ? '' : 's'}
+        </span>
+      </h4>
+      <div className="cs-jsonld-list">
+        {blocks.map((block, i) => (
+          <JsonLdBlockCard key={i} block={block} index={i} />
+        ))}
+      </div>
+    </section>
   );
 }
 
@@ -81,7 +182,16 @@ export function SeoTab() {
           </div>
           <div>
             <dt>JSON-LD</dt>
-            <dd>{meta.jsonLd.length} block(s)</dd>
+            <dd>
+              {meta.jsonLd.length === 0 ? (
+                <em>none</em>
+              ) : (
+                <>
+                  {meta.jsonLd.length} block{meta.jsonLd.length === 1 ? '' : 's'}{' '}
+                  <span className="cs-seo-len">(see below)</span>
+                </>
+              )}
+            </dd>
           </div>
         </dl>
       </section>
@@ -95,6 +205,8 @@ export function SeoTab() {
         <h4 className="cs-section-title">Facebook / Slack preview</h4>
         <CardPreview meta={meta} kind="facebook" />
       </section>
+
+      <JsonLdSection blocks={meta.jsonLd} />
 
       {issues.length > 0 && (
         <section className="cs-section">

--- a/src/content/panel/styles.css
+++ b/src/content/panel/styles.css
@@ -1196,3 +1196,147 @@
   background: var(--cs-accent-bg);
   color: var(--cs-accent);
 }
+
+/* ============================================================
+   JSON-LD collapsible cards (SEO tab → Structured data section)
+   ============================================================ */
+
+.cs-section-count {
+  font-weight: 400;
+  color: var(--cs-text-subtle);
+  font-size: 11px;
+}
+
+.cs-jsonld-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cs-jsonld-card {
+  border: 1px solid var(--cs-border);
+  border-radius: 6px;
+  background: var(--cs-bg-elevated);
+  overflow: hidden;
+}
+
+.cs-jsonld-card[open] {
+  border-color: var(--cs-accent);
+}
+
+.cs-jsonld-card-invalid {
+  border-color: var(--cs-danger);
+}
+
+.cs-jsonld-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  font-size: 12px;
+  color: var(--cs-text);
+}
+
+/* Hide the default disclosure triangle (Chrome / Safari / Firefox). */
+.cs-jsonld-summary::-webkit-details-marker {
+  display: none;
+}
+
+.cs-jsonld-summary::marker {
+  display: none;
+  content: '';
+}
+
+.cs-jsonld-summary:hover {
+  background: var(--cs-bg-hover);
+}
+
+.cs-jsonld-chevron {
+  display: inline-block;
+  width: 10px;
+  font-size: 9px;
+  color: var(--cs-text-subtle);
+  transition: transform 0.12s ease;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.cs-jsonld-card[open] .cs-jsonld-chevron {
+  transform: rotate(90deg);
+}
+
+.cs-jsonld-index {
+  font-family: var(--cs-mono);
+  font-size: 10px;
+  color: var(--cs-text-subtle);
+  background: var(--cs-bg);
+  border: 1px solid var(--cs-border);
+  border-radius: 3px;
+  padding: 1px 4px;
+  flex-shrink: 0;
+}
+
+.cs-jsonld-type {
+  font-weight: 600;
+  color: var(--cs-accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 0;
+  max-width: 60%;
+}
+
+.cs-jsonld-card-invalid .cs-jsonld-type {
+  color: var(--cs-danger);
+}
+
+.cs-jsonld-count {
+  font-weight: 400;
+  color: var(--cs-text-subtle);
+}
+
+.cs-jsonld-secondary {
+  font-size: 11px;
+  color: var(--cs-text-muted);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cs-jsonld-copy {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.cs-jsonld-body {
+  margin: 0;
+  border-top: 1px solid var(--cs-border);
+  border-radius: 0;
+  max-height: 360px;
+  overflow: auto;
+  font-size: 11px;
+}
+
+.cs-jsonld-error {
+  margin: 0;
+  padding: 8px 10px;
+  font-size: 11px;
+  color: var(--cs-danger);
+  border-bottom: 1px solid var(--cs-border);
+}
+
+.cs-jsonld-raw {
+  margin: 0;
+  padding: 8px;
+  background: var(--cs-bg);
+  font-family: var(--cs-mono);
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--cs-text-muted);
+}

--- a/src/content/panel/styles.css
+++ b/src/content/panel/styles.css
@@ -1224,8 +1224,13 @@
   border-color: var(--cs-accent);
 }
 
-.cs-jsonld-card-invalid {
+.cs-jsonld-card-invalid,
+.cs-jsonld-card-has-error {
   border-color: var(--cs-danger);
+}
+
+.cs-jsonld-card-has-warn {
+  border-color: var(--cs-warning);
 }
 
 .cs-jsonld-summary {
@@ -1339,4 +1344,82 @@
   white-space: pre-wrap;
   word-break: break-all;
   color: var(--cs-text-muted);
+}
+
+/* Severity badge in the card summary + section-level aggregate counters. */
+
+.cs-jsonld-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  font-family: var(--cs-mono);
+  letter-spacing: 0.02em;
+}
+
+.cs-jsonld-badge-inline {
+  margin-left: 8px;
+}
+
+.cs-jsonld-badge-error {
+  background: rgba(220, 38, 38, 0.15);
+  color: var(--cs-danger);
+}
+
+.cs-jsonld-badge-warn {
+  background: rgba(217, 119, 6, 0.15);
+  color: var(--cs-warning);
+}
+
+.cs-jsonld-badge-info {
+  background: var(--cs-accent-bg);
+  color: var(--cs-accent);
+}
+
+/* Issues list rendered above the JSON pre when a card is expanded.
+   Reuses the existing .cs-seo-issue tone classes for visual consistency
+   with the page-level Issues section, but styled tighter for inline use. */
+
+.cs-jsonld-issues {
+  list-style: none;
+  margin: 0;
+  padding: 6px 8px;
+  border-top: 1px solid var(--cs-border);
+  background: var(--cs-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cs-jsonld-issues .cs-seo-issue {
+  padding: 5px 8px;
+  font-size: 11px;
+  line-height: 1.4;
+  align-items: flex-start;
+}
+
+.cs-jsonld-issue-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.cs-jsonld-issue-path {
+  font-family: var(--cs-mono);
+  font-size: 10px;
+  color: var(--cs-text-subtle);
+  background: var(--cs-bg-elevated);
+  padding: 1px 4px;
+  border-radius: 3px;
+  align-self: flex-start;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/lib/json-highlight.ts
+++ b/src/lib/json-highlight.ts
@@ -1,0 +1,45 @@
+/**
+ * Pretty-prints a value as syntax-highlighted HTML, suitable for use with
+ * `dangerouslySetInnerHTML` inside a `<pre>`.
+ *
+ * Used by the JSON tab and the SEO tab's JSON-LD viewer; centralized here so
+ * both surfaces look identical and pick up CSS theme tokens from a single
+ * place (`.cs-json-key`, `.cs-json-string`, etc.).
+ *
+ * The HTML output is XSS-safe — every `&`, `<`, `>` in the source value is
+ * escaped before the regex tags strings/numbers/booleans/null. The regex
+ * never produces tags that aren't `<span class="cs-json-…">`.
+ *
+ * Note: the original implementation used a zero-width lookahead `(?=\s*:)`
+ * to detect keys, then checked `match.endsWith(':')` in the callback —
+ * which never fired because the colon was outside the match. As a result,
+ * keys silently rendered with the same green as string values for the
+ * lifetime of the JSON tab. This version captures the colon inside the
+ * match, so keys now correctly pick up `.cs-json-key`.
+ */
+export function highlightJson(value: unknown): string {
+  const json = JSON.stringify(value, null, 2);
+  if (json === undefined) return '';
+  return json
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(
+      /("(\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*"\s*:)|("(\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*")|(\b(?:true|false)\b)|(\bnull\b)|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g,
+      (match: string) => {
+        if (match.endsWith(':')) {
+          return `<span class="cs-json-key">${match}</span>`;
+        }
+        if (match.startsWith('"')) {
+          return `<span class="cs-json-string">${match}</span>`;
+        }
+        if (match === 'true' || match === 'false') {
+          return `<span class="cs-json-bool">${match}</span>`;
+        }
+        if (match === 'null') {
+          return `<span class="cs-json-null">${match}</span>`;
+        }
+        return `<span class="cs-json-number">${match}</span>`;
+      }
+    );
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -57,6 +57,93 @@ function readJsonLd(doc: Document): unknown[] {
   return blocks;
 }
 
+/**
+ * One-line description of a JSON-LD block, suitable for the collapsed
+ * card header in the SEO tab. Tries hard to extract the most useful
+ * signal — `@type` (or list of types in a `@graph`) plus a name/headline
+ * if one is present — and falls back to a generic label when the block
+ * doesn't follow the schema.org conventions.
+ */
+export interface JsonLdSummary {
+  readonly typeLabel: string;
+  readonly secondary: string | null;
+  readonly invalid: boolean;
+  readonly itemCount: number | null;
+}
+
+const MAX_SECONDARY = 80;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Schema.org `@type` values can be a string, an array of strings, or
+ * occasionally a nested array. Normalize into a clean string list.
+ */
+function readTypes(node: unknown): string[] {
+  if (!isRecord(node)) return [];
+  const raw = node['@type'];
+  if (typeof raw === 'string') return [raw];
+  if (Array.isArray(raw)) return raw.filter((t): t is string => typeof t === 'string');
+  return [];
+}
+
+/**
+ * Pick the best human-readable label out of the common name-ish fields.
+ * `headline` is the standard for `Article`/`NewsArticle`; `name` is the
+ * fallback for almost everything else; `url` is a last resort.
+ */
+function readSecondary(node: unknown): string | null {
+  if (!isRecord(node)) return null;
+  for (const field of ['headline', 'name', 'title', 'url'] as const) {
+    const v = node[field];
+    if (typeof v === 'string' && v.trim()) {
+      const trimmed = v.trim();
+      return trimmed.length > MAX_SECONDARY ? `${trimmed.slice(0, MAX_SECONDARY - 1)}…` : trimmed;
+    }
+  }
+  return null;
+}
+
+export function summarizeJsonLd(block: unknown): JsonLdSummary {
+  if (isRecord(block) && block.__invalid === true) {
+    return { typeLabel: 'Invalid JSON', secondary: null, invalid: true, itemCount: null };
+  }
+
+  // `@graph` is the canonical "bag of multiple top-level entities" pattern
+  // — Yoast and Rank Math both emit it. Show the count + the unique types
+  // in the graph so the user knows what they're about to expand.
+  if (isRecord(block) && Array.isArray(block['@graph'])) {
+    const items = block['@graph'];
+    const types = new Set<string>();
+    for (const item of items) for (const t of readTypes(item)) types.add(t);
+    const typeLabel =
+      types.size === 0
+        ? '@graph'
+        : `@graph (${[...types].sort().slice(0, 4).join(', ')}${types.size > 4 ? '…' : ''})`;
+    return { typeLabel, secondary: null, invalid: false, itemCount: items.length };
+  }
+
+  // A bare top-level array of entities — unusual but valid.
+  if (Array.isArray(block)) {
+    const types = new Set<string>();
+    for (const item of block) for (const t of readTypes(item)) types.add(t);
+    const typeLabel =
+      types.size === 0 ? 'Array' : `Array (${[...types].sort().slice(0, 4).join(', ')})`;
+    return { typeLabel, secondary: null, invalid: false, itemCount: block.length };
+  }
+
+  const types = readTypes(block);
+  const typeLabel = types.length === 0 ? 'Untyped object' : types.join(' / ');
+  return {
+    typeLabel,
+    secondary: readSecondary(block),
+    invalid: false,
+    itemCount: null,
+  };
+}
+
 export function extractSeoMeta(doc: Document = document): SeoMeta {
   return {
     title: doc.title ?? '',

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -243,3 +243,374 @@ export function lintSeo(meta: SeoMeta): SeoIssue[] {
 
   return issues;
 }
+
+/* ============================================================
+   JSON-LD validator
+   ============================================================ */
+
+export interface JsonLdIssue {
+  /** Stable rule id, e.g. `missing-context`. Useful for tests + telemetry. */
+  readonly code: string;
+  readonly severity: 'info' | 'warn' | 'error';
+  readonly message: string;
+  /** Index into the `meta.jsonLd` array — i.e. which `<script>` tag. */
+  readonly blockIndex: number;
+  /** Dotted path inside the block, e.g. `@graph[1].author`. Empty = root. */
+  readonly path: string;
+}
+
+const HEADLINE_MAX = 110; // Google's documented Article rich-result limit
+const SCHEMA_HOSTS = new Set(['schema.org', 'www.schema.org']);
+const ARTICLE_TYPES = new Set([
+  'Article',
+  'NewsArticle',
+  'BlogPosting',
+  'Report',
+  'ReviewArticle',
+  'AnalysisNewsArticle',
+  'OpinionNewsArticle',
+  'BackgroundNewsArticle',
+]);
+
+function isIsoDate(value: unknown): boolean {
+  if (typeof value !== 'string' || !value) return false;
+  // Accept ISO 8601 with or without time/zone. Be lenient about the
+  // separator + timezone shape; reject anything that isn't a valid Date.
+  if (!/^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/.test(value))
+    return false;
+  return !Number.isNaN(Date.parse(value));
+}
+
+function isAbsoluteUrl(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  try {
+    const u = new URL(value);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isContextValueValid(ctx: unknown): boolean {
+  // Schema.org allows strings (`"https://schema.org"`), arrays, or objects
+  // (`{ "@vocab": "https://schema.org/" }`). We only validate the first
+  // form deeply since 99% of real-world Article markup uses it.
+  if (typeof ctx === 'string') {
+    try {
+      const u = new URL(ctx);
+      return SCHEMA_HOSTS.has(u.hostname);
+    } catch {
+      return false;
+    }
+  }
+  if (Array.isArray(ctx)) return ctx.some(isContextValueValid);
+  return isRecord(ctx); // Trust object @context shapes.
+}
+
+function hasNonEmptyValue(node: Record<string, unknown>, ...keys: string[]): boolean {
+  for (const k of keys) {
+    const v = node[k];
+    if (v === undefined || v === null) continue;
+    if (typeof v === 'string' && v.trim() === '') continue;
+    if (Array.isArray(v) && v.length === 0) continue;
+    return true;
+  }
+  return false;
+}
+
+function joinPath(base: string, segment: string): string {
+  if (!base) return segment;
+  if (segment.startsWith('[')) return `${base}${segment}`;
+  return `${base}.${segment}`;
+}
+
+/**
+ * Inspect a single schema.org entity (no `@graph` recursion — that's
+ * unwrapped by the caller). Pushes any issues found into `out`.
+ */
+function lintEntity(entity: unknown, blockIndex: number, path: string, out: JsonLdIssue[]): void {
+  if (!isRecord(entity)) return;
+  const types = readTypes(entity);
+
+  if (types.length === 0) {
+    out.push({
+      code: 'missing-type',
+      severity: 'warn',
+      message: 'Entity has no @type — search engines will treat it as opaque data.',
+      blockIndex,
+      path,
+    });
+  }
+
+  // ── Article-family checks ───────────────────────────────────────────────
+  if (types.some((t) => ARTICLE_TYPES.has(t))) {
+    if (!hasNonEmptyValue(entity, 'headline')) {
+      out.push({
+        code: 'article-missing-headline',
+        severity: 'error',
+        message: `${types[0]} is missing "headline" — required for Google rich results.`,
+        blockIndex,
+        path,
+      });
+    } else if (typeof entity.headline === 'string' && entity.headline.length > HEADLINE_MAX) {
+      out.push({
+        code: 'article-headline-long',
+        severity: 'warn',
+        message: `"headline" is ${entity.headline.length} chars (Google truncates above ${HEADLINE_MAX}).`,
+        blockIndex,
+        path: joinPath(path, 'headline'),
+      });
+    }
+
+    if (!hasNonEmptyValue(entity, 'image')) {
+      out.push({
+        code: 'article-missing-image',
+        severity: 'error',
+        message: `${types[0]} is missing "image" — required for Google rich results.`,
+        blockIndex,
+        path,
+      });
+    } else {
+      // The `image` field can be a string URL, an ImageObject, an array
+      // of either, or a single object inside an array. Pull out every
+      // candidate URL string and check it's absolute — relative paths
+      // silently break Google's image fetch on the rich-result crawl.
+      const imageUrls: { url: unknown; subPath: string }[] = [];
+      const candidates = Array.isArray(entity.image) ? entity.image : [entity.image];
+      candidates.forEach((c, i) => {
+        const subPath = candidates.length > 1 ? `image[${i}]` : 'image';
+        if (typeof c === 'string') imageUrls.push({ url: c, subPath });
+        else if (isRecord(c) && 'url' in c)
+          imageUrls.push({ url: c.url, subPath: `${subPath}.url` });
+      });
+      for (const { url, subPath } of imageUrls) {
+        if (typeof url === 'string' && url && !isAbsoluteUrl(url)) {
+          out.push({
+            code: 'article-image-relative',
+            severity: 'warn',
+            message: `"image" must be an absolute URL — got ${JSON.stringify(url)}.`,
+            blockIndex,
+            path: joinPath(path, subPath),
+          });
+        }
+      }
+    }
+
+    if (!hasNonEmptyValue(entity, 'datePublished')) {
+      out.push({
+        code: 'article-missing-date-published',
+        severity: 'error',
+        message: `${types[0]} is missing "datePublished" — required for Google rich results.`,
+        blockIndex,
+        path,
+      });
+    } else if (!isIsoDate(entity.datePublished)) {
+      out.push({
+        code: 'article-bad-date-published',
+        severity: 'warn',
+        message: `"datePublished" is not a valid ISO 8601 date (got ${JSON.stringify(entity.datePublished)}).`,
+        blockIndex,
+        path: joinPath(path, 'datePublished'),
+      });
+    }
+
+    if (entity.dateModified !== undefined && !isIsoDate(entity.dateModified)) {
+      out.push({
+        code: 'article-bad-date-modified',
+        severity: 'warn',
+        message: `"dateModified" is not a valid ISO 8601 date (got ${JSON.stringify(entity.dateModified)}).`,
+        blockIndex,
+        path: joinPath(path, 'dateModified'),
+      });
+    }
+
+    if (
+      isIsoDate(entity.datePublished) &&
+      isIsoDate(entity.dateModified) &&
+      Date.parse(entity.dateModified as string) < Date.parse(entity.datePublished as string)
+    ) {
+      out.push({
+        code: 'article-modified-before-published',
+        severity: 'warn',
+        message: '"dateModified" is earlier than "datePublished" — likely a copy-paste bug.',
+        blockIndex,
+        path,
+      });
+    }
+
+    if (!hasNonEmptyValue(entity, 'author')) {
+      out.push({
+        code: 'article-missing-author',
+        severity: 'warn',
+        message: `${types[0]} is missing "author" — recommended for Google rich results.`,
+        blockIndex,
+        path,
+      });
+    }
+
+    if (!hasNonEmptyValue(entity, 'publisher')) {
+      out.push({
+        code: 'article-missing-publisher',
+        severity: 'info',
+        message: `${types[0]} is missing "publisher".`,
+        blockIndex,
+        path,
+      });
+    }
+  }
+
+  // ── BreadcrumbList checks ───────────────────────────────────────────────
+  if (types.includes('BreadcrumbList')) {
+    const items = entity.itemListElement;
+    if (!Array.isArray(items) || items.length === 0) {
+      out.push({
+        code: 'breadcrumb-empty',
+        severity: 'warn',
+        message: 'BreadcrumbList has no itemListElement entries.',
+        blockIndex,
+        path: joinPath(path, 'itemListElement'),
+      });
+    } else {
+      const positions: number[] = [];
+      items.forEach((item, i) => {
+        const itemPath = joinPath(path, `itemListElement[${i}]`);
+        if (!isRecord(item)) return;
+        const pos = item.position;
+        if (typeof pos !== 'number') {
+          out.push({
+            code: 'breadcrumb-missing-position',
+            severity: 'warn',
+            message: `Breadcrumb item ${i} is missing a numeric "position".`,
+            blockIndex,
+            path: itemPath,
+          });
+        } else {
+          positions.push(pos);
+        }
+        if (!hasNonEmptyValue(item, 'name')) {
+          out.push({
+            code: 'breadcrumb-missing-name',
+            severity: 'warn',
+            message: `Breadcrumb item ${i} is missing "name".`,
+            blockIndex,
+            path: itemPath,
+          });
+        }
+        if (!hasNonEmptyValue(item, 'item', '@id')) {
+          out.push({
+            code: 'breadcrumb-missing-item',
+            severity: 'info',
+            message: `Breadcrumb item ${i} has no "item" or "@id" URL — final crumb is allowed to omit this.`,
+            blockIndex,
+            path: itemPath,
+          });
+        }
+      });
+      // Positions should be 1, 2, 3, … contiguous. Catch the off-by-one
+      // and "everyone uses 1" bugs.
+      if (positions.length === items.length) {
+        const sorted = [...positions].sort((a, b) => a - b);
+        const expected = Array.from({ length: sorted.length }, (_, i) => i + 1);
+        if (sorted.join(',') !== expected.join(',')) {
+          out.push({
+            code: 'breadcrumb-bad-positions',
+            severity: 'warn',
+            message: `Breadcrumb positions should be 1, 2, … ${items.length} (got [${sorted.join(', ')}]).`,
+            blockIndex,
+            path: joinPath(path, 'itemListElement'),
+          });
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Validate every JSON-LD block on the page. Walks into `@graph` so each
+ * inner entity is checked individually, and runs a cross-block pass to
+ * catch duplicate `@id` values that would cause search engines to merge
+ * entities.
+ */
+export function lintJsonLd(blocks: readonly unknown[]): JsonLdIssue[] {
+  const issues: JsonLdIssue[] = [];
+  const seenIds = new Map<string, number[]>();
+
+  blocks.forEach((block, blockIndex) => {
+    // Invalid blocks are surfaced by the card UI itself; skip them here.
+    if (isRecord(block) && block.__invalid === true) return;
+
+    // ── Universal: @context ───────────────────────────────────────────────
+    if (isRecord(block)) {
+      const ctx = block['@context'];
+      if (ctx === undefined) {
+        issues.push({
+          code: 'missing-context',
+          severity: 'error',
+          message: 'Block is missing "@context" — required for JSON-LD.',
+          blockIndex,
+          path: '',
+        });
+      } else if (!isContextValueValid(ctx)) {
+        issues.push({
+          code: 'invalid-context',
+          severity: 'error',
+          message: `"@context" is not a recognized schema.org URL (got ${JSON.stringify(ctx)}).`,
+          blockIndex,
+          path: '@context',
+        });
+      }
+    }
+
+    // ── Walk @graph or just lint the root entity ─────────────────────────
+    if (isRecord(block) && Array.isArray(block['@graph'])) {
+      block['@graph'].forEach((entity, i) => {
+        lintEntity(entity, blockIndex, `@graph[${i}]`, issues);
+        collectIds(entity, blockIndex, `@graph[${i}]`, seenIds);
+      });
+    } else if (Array.isArray(block)) {
+      block.forEach((entity, i) => {
+        lintEntity(entity, blockIndex, `[${i}]`, issues);
+        collectIds(entity, blockIndex, `[${i}]`, seenIds);
+      });
+    } else {
+      lintEntity(block, blockIndex, '', issues);
+      collectIds(block, blockIndex, '', seenIds);
+    }
+  });
+
+  // ── Cross-block: duplicate @id ─────────────────────────────────────────
+  for (const [id, occurrences] of seenIds) {
+    if (occurrences.length > 1) {
+      const uniqueBlocks = [...new Set(occurrences)].sort((a, b) => a - b);
+      // Only flag duplicates that span multiple blocks; in-block dupes are
+      // legal (e.g. an @id that's both a top-level entity and referenced
+      // inside an @graph).
+      if (uniqueBlocks.length > 1) {
+        issues.push({
+          code: 'duplicate-id',
+          severity: 'warn',
+          message: `@id ${JSON.stringify(id)} appears in blocks #${uniqueBlocks.map((i) => i + 1).join(', #')} — search engines may merge or drop entities.`,
+          blockIndex: uniqueBlocks[0]!,
+          path: '@id',
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+function collectIds(
+  entity: unknown,
+  blockIndex: number,
+  _path: string,
+  out: Map<string, number[]>
+): void {
+  if (!isRecord(entity)) return;
+  const id = entity['@id'];
+  if (typeof id === 'string' && id.trim()) {
+    const list = out.get(id) ?? [];
+    list.push(blockIndex);
+    out.set(id, list);
+  }
+}

--- a/tests/lib/json-highlight.test.ts
+++ b/tests/lib/json-highlight.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { highlightJson } from '@/lib/json-highlight';
+
+describe('highlightJson', () => {
+  it('wraps strings, numbers, booleans, and null in span classes', () => {
+    const html = highlightJson({ name: 'Alice', age: 30, active: true, ref: null });
+    expect(html).toContain('<span class="cs-json-key">"name":</span>');
+    expect(html).toContain('<span class="cs-json-string">"Alice"</span>');
+    expect(html).toContain('<span class="cs-json-number">30</span>');
+    expect(html).toContain('<span class="cs-json-bool">true</span>');
+    expect(html).toContain('<span class="cs-json-null">null</span>');
+  });
+
+  it('escapes HTML in string values so the host page cannot be tag-injected', () => {
+    const html = highlightJson({ note: '<img src=x onerror=alert(1)>' });
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('handles nested arrays and objects', () => {
+    const html = highlightJson({
+      items: [
+        { id: 1, label: 'one' },
+        { id: 2, label: 'two' },
+      ],
+    });
+    expect(html).toContain('<span class="cs-json-key">"items":</span>');
+    expect(html).toContain('<span class="cs-json-key">"label":</span>');
+    expect(html).toContain('<span class="cs-json-string">"one"</span>');
+    expect(html).toContain('<span class="cs-json-number">2</span>');
+  });
+
+  it('returns an empty string for values JSON.stringify drops (functions, undefined)', () => {
+    expect(highlightJson(undefined)).toBe('');
+    expect(highlightJson(() => 1)).toBe('');
+  });
+});

--- a/tests/lib/seo.test.ts
+++ b/tests/lib/seo.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { extractSeoMeta, lintSeo } from '@/lib/seo';
+import { extractSeoMeta, lintSeo, summarizeJsonLd } from '@/lib/seo';
 
 function setMeta(name: string, content: string, attr: 'name' | 'property' = 'name') {
   const el = document.createElement('meta');
@@ -84,5 +84,77 @@ describe('lintSeo', () => {
     });
     expect(issues.filter((i) => i.severity === 'error')).toHaveLength(0);
     expect(issues.filter((i) => i.severity === 'warn')).toHaveLength(0);
+  });
+});
+
+describe('summarizeJsonLd', () => {
+  it('extracts a single @type with its headline', () => {
+    const summary = summarizeJsonLd({
+      '@type': 'NewsArticle',
+      headline: 'Why the panel matters',
+    });
+    expect(summary).toEqual({
+      typeLabel: 'NewsArticle',
+      secondary: 'Why the panel matters',
+      invalid: false,
+      itemCount: null,
+    });
+  });
+
+  it('joins multiple @type values with a slash', () => {
+    const summary = summarizeJsonLd({
+      '@type': ['Article', 'NewsArticle'],
+      name: 'Multi-type article',
+    });
+    expect(summary.typeLabel).toBe('Article / NewsArticle');
+    expect(summary.secondary).toBe('Multi-type article');
+  });
+
+  it('summarizes a Yoast-style @graph as a count + sorted unique types', () => {
+    const summary = summarizeJsonLd({
+      '@context': 'https://schema.org',
+      '@graph': [
+        { '@type': 'WebSite', name: 'Site' },
+        { '@type': 'Article', headline: 'Headline' },
+        { '@type': 'BreadcrumbList' },
+      ],
+    });
+    expect(summary.typeLabel).toBe('@graph (Article, BreadcrumbList, WebSite)');
+    expect(summary.itemCount).toBe(3);
+    expect(summary.invalid).toBe(false);
+  });
+
+  it('caps a long secondary string with an ellipsis', () => {
+    const summary = summarizeJsonLd({
+      '@type': 'Article',
+      headline: 'a'.repeat(120),
+    });
+    expect(summary.secondary).toMatch(/…$/);
+    expect(summary.secondary?.length).toBeLessThanOrEqual(80);
+  });
+
+  it('falls back to "Untyped object" when @type is missing', () => {
+    const summary = summarizeJsonLd({ name: 'Just a name' });
+    expect(summary.typeLabel).toBe('Untyped object');
+    expect(summary.secondary).toBe('Just a name');
+  });
+
+  it('marks blocks the extractor flagged as invalid', () => {
+    const summary = summarizeJsonLd({ __invalid: true, raw: 'this is not json' });
+    expect(summary).toEqual({
+      typeLabel: 'Invalid JSON',
+      secondary: null,
+      invalid: true,
+      itemCount: null,
+    });
+  });
+
+  it('handles a top-level array of entities', () => {
+    const summary = summarizeJsonLd([
+      { '@type': 'Person', name: 'Alice' },
+      { '@type': 'Person', name: 'Bob' },
+    ]);
+    expect(summary.typeLabel).toBe('Array (Person)');
+    expect(summary.itemCount).toBe(2);
   });
 });

--- a/tests/lib/seo.test.ts
+++ b/tests/lib/seo.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { extractSeoMeta, lintSeo, summarizeJsonLd } from '@/lib/seo';
+import { extractSeoMeta, lintJsonLd, lintSeo, summarizeJsonLd } from '@/lib/seo';
 
 function setMeta(name: string, content: string, attr: 'name' | 'property' = 'name') {
   const el = document.createElement('meta');
@@ -156,5 +156,219 @@ describe('summarizeJsonLd', () => {
     ]);
     expect(summary.typeLabel).toBe('Array (Person)');
     expect(summary.itemCount).toBe(2);
+  });
+});
+
+describe('lintJsonLd', () => {
+  /** Build a "perfect" NewsArticle that should produce zero issues. */
+  function goodArticle(overrides: Record<string, unknown> = {}) {
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'NewsArticle',
+      headline: 'A perfectly normal headline',
+      image: 'https://example.com/img.jpg',
+      datePublished: '2026-05-13T10:00:00Z',
+      dateModified: '2026-05-13T11:00:00Z',
+      author: { '@type': 'Person', name: 'Alice' },
+      publisher: { '@type': 'Organization', name: 'NY Mag' },
+      ...overrides,
+    };
+  }
+
+  function codes(blocks: readonly unknown[]): string[] {
+    return lintJsonLd(blocks).map((i) => i.code);
+  }
+
+  it('returns no issues for a healthy NewsArticle block', () => {
+    expect(lintJsonLd([goodArticle()])).toEqual([]);
+  });
+
+  it('flags missing @context as an error', () => {
+    const block = goodArticle();
+    delete (block as { '@context'?: unknown })['@context'];
+    expect(codes([block])).toContain('missing-context');
+  });
+
+  it('flags an @context that is not a schema.org URL', () => {
+    const block = goodArticle({ '@context': 'https://shema.org' });
+    const issues = lintJsonLd([block]);
+    const ctx = issues.find((i) => i.code === 'invalid-context');
+    expect(ctx?.severity).toBe('error');
+    expect(ctx?.path).toBe('@context');
+  });
+
+  it('accepts http:// and trailing-slash variants of schema.org', () => {
+    expect(codes([goodArticle({ '@context': 'http://schema.org' })])).not.toContain(
+      'invalid-context'
+    );
+    expect(codes([goodArticle({ '@context': 'https://schema.org/' })])).not.toContain(
+      'invalid-context'
+    );
+  });
+
+  it('flags missing @type with a warning', () => {
+    expect(codes([{ '@context': 'https://schema.org', name: 'Untyped' }])).toContain(
+      'missing-type'
+    );
+  });
+
+  it('reports every required Article field that is missing', () => {
+    const block: Record<string, unknown> = { '@context': 'https://schema.org', '@type': 'Article' };
+    const issues = codes([block]);
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        'article-missing-headline',
+        'article-missing-image',
+        'article-missing-date-published',
+        'article-missing-author',
+        'article-missing-publisher',
+      ])
+    );
+  });
+
+  it('warns when the headline exceeds the Google rich-result limit', () => {
+    const block = goodArticle({ headline: 'a'.repeat(120) });
+    const issues = lintJsonLd([block]);
+    const long = issues.find((i) => i.code === 'article-headline-long');
+    expect(long?.severity).toBe('warn');
+    expect(long?.path).toBe('headline');
+  });
+
+  it('flags relative image URLs (string form and ImageObject form)', () => {
+    const stringForm = lintJsonLd([goodArticle({ image: '/img.jpg' })]);
+    expect(stringForm.map((i) => i.code)).toContain('article-image-relative');
+    expect(stringForm.find((i) => i.code === 'article-image-relative')?.path).toBe('image');
+
+    const objectForm = lintJsonLd([
+      goodArticle({ image: { '@type': 'ImageObject', url: 'images/x.jpg' } }),
+    ]);
+    expect(objectForm.find((i) => i.code === 'article-image-relative')?.path).toBe('image.url');
+
+    const arrayForm = lintJsonLd([
+      goodArticle({
+        image: ['https://example.com/ok.jpg', '/relative.jpg'],
+      }),
+    ]);
+    const arrayIssue = arrayForm.find((i) => i.code === 'article-image-relative');
+    expect(arrayIssue?.path).toBe('image[1]');
+  });
+
+  it('flags non-ISO datePublished and dateModified strings', () => {
+    const block = goodArticle({ datePublished: 'May 13 2026', dateModified: 'tomorrow' });
+    const issues = codes([block]);
+    expect(issues).toContain('article-bad-date-published');
+    expect(issues).toContain('article-bad-date-modified');
+  });
+
+  it('warns when dateModified is earlier than datePublished', () => {
+    const block = goodArticle({
+      datePublished: '2026-05-13T10:00:00Z',
+      dateModified: '2026-05-12T10:00:00Z',
+    });
+    expect(codes([block])).toContain('article-modified-before-published');
+  });
+
+  it('walks into @graph and lints each inner entity', () => {
+    const issues = lintJsonLd([
+      {
+        '@context': 'https://schema.org',
+        '@graph': [
+          { '@type': 'WebSite', name: 'Site' }, // OK (not Article-family)
+          { '@type': 'Article', name: 'Inner' }, // missing required Article fields
+        ],
+      },
+    ]);
+    const articleIssues = issues.filter((i) => i.path.startsWith('@graph[1]'));
+    expect(articleIssues.map((i) => i.code)).toEqual(
+      expect.arrayContaining(['article-missing-headline', 'article-missing-image'])
+    );
+  });
+
+  it('flags BreadcrumbList items missing required fields', () => {
+    const block = {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://example.com/' },
+        { '@type': 'ListItem', name: 'Section' }, // missing position + item
+      ],
+    };
+    expect(codes([block])).toEqual(
+      expect.arrayContaining(['breadcrumb-missing-position', 'breadcrumb-missing-item'])
+    );
+  });
+
+  it('flags BreadcrumbList positions that are not 1, 2, … N', () => {
+    const block = {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://example.com/' },
+        { '@type': 'ListItem', position: 2, name: 'Section', item: 'https://example.com/s' },
+        { '@type': 'ListItem', position: 5, name: 'Page', item: 'https://example.com/x' }, // bad
+      ],
+    };
+    expect(codes([block])).toContain('breadcrumb-bad-positions');
+  });
+
+  it('skips position contiguity check when any item is missing a position', () => {
+    // We can't reliably tell if positions are contiguous if some are
+    // missing — a single "breadcrumb-missing-position" warning is enough.
+    const block = {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://example.com/' },
+        { '@type': 'ListItem', name: 'Gap', item: 'https://example.com/g' }, // no position
+        { '@type': 'ListItem', position: 3, name: 'End', item: 'https://example.com/e' },
+      ],
+    };
+    expect(codes([block])).not.toContain('breadcrumb-bad-positions');
+  });
+
+  it('flags an empty BreadcrumbList', () => {
+    expect(
+      codes([{ '@context': 'https://schema.org', '@type': 'BreadcrumbList', itemListElement: [] }])
+    ).toContain('breadcrumb-empty');
+  });
+
+  it('detects duplicate @id values across blocks (not within a single block)', () => {
+    // Same @id in two separate blocks → flagged.
+    const dup = lintJsonLd([
+      {
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        '@id': 'https://example.com/x',
+        headline: 'h',
+        image: 'i',
+        datePublished: '2026-01-01',
+        author: 'a',
+        publisher: 'p',
+      },
+      { '@context': 'https://schema.org', '@type': 'WebSite', '@id': 'https://example.com/x' },
+    ]);
+    expect(dup.map((i) => i.code)).toContain('duplicate-id');
+
+    // Same @id appearing twice in one block (graph self-reference) → not flagged.
+    const single = lintJsonLd([
+      {
+        '@context': 'https://schema.org',
+        '@id': 'https://example.com/x',
+        '@graph': [{ '@type': 'WebSite', '@id': 'https://example.com/x' }],
+      },
+    ]);
+    expect(single.map((i) => i.code)).not.toContain('duplicate-id');
+  });
+
+  it('skips blocks the extractor flagged as invalid', () => {
+    expect(lintJsonLd([{ __invalid: true, raw: 'broken json' }])).toEqual([]);
+  });
+
+  it('attaches blockIndex so callers can group issues per card', () => {
+    const issues = lintJsonLd([
+      goodArticle(), // index 0 — clean
+      { '@type': 'Article' }, // index 1 — many issues
+    ]);
+    expect(issues.every((i) => i.blockIndex === 1)).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

The SEO tab's JSON-LD row used to be a one-liner that just said _"2 block(s)"_. You had no way to see what was in the structured data, and no way to tell whether it was valid. This PR turns that line into a proper inspector **and** validator.

## What's new

### 1. Collapsible JSON-LD viewer

A new "Structured data (JSON-LD)" section under the social previews with one card per `<script type="application/ld+json">` block on the page.

- Native `<details>` / `<summary>` for accessibility (keyboard, screen readers, browser find-in-page).
- **Collapsed header** shows: block index, schema.org `@type` (or types joined with ` / `), the most useful name field (\`headline\` → \`name\` → \`title\` → \`url\`), and a copy button.
- **Expanded body** shows the full JSON pretty-printed with the same syntax highlighting as the JSON tab. The \`<pre>\` is only rendered once the user opens the card so big \`@graph\` payloads don't run the highlighter regex if no one looks at them.
- **Smart \`@graph\` summaries**: \`@graph (Article, BreadcrumbList, WebSite) · 3 items\` for Yoast/Rank-Math style blocks.
- **Invalid blocks** get a red border, raw-text fallback view, and a clear _"this isn't valid JSON"_ header.

### 2. Inline JSON-LD validator

A focused schema.org linter that runs over every block and surfaces issues directly inside each card. Goal: high signal for news/CMS pages, not a full schema.org validator. Catches the bugs that actually break Google rich results in the wild.

#### Checks

| Category    | Code                                  | Severity  | What it flags                                              |
| ----------- | ------------------------------------- | --------- | ---------------------------------------------------------- |
| Universal   | \`missing-context\`                     | error     | Block has no \`@context\`                                    |
|             | \`invalid-context\`                     | error     | Not a schema.org URL (e.g. \`https://shema.org\` typo)       |
|             | \`missing-type\`                        | warn      | Entity has no \`@type\`                                      |
| Article     | \`article-missing-headline\`            | error     | Required for Google rich results                           |
|             | \`article-headline-long\`               | warn      | > 110 chars (Google's documented limit)                    |
|             | \`article-missing-image\`               | error     | Required for Google rich results                           |
|             | \`article-image-relative\`              | warn      | Image URL must be absolute (handles string / ImageObject / array forms with precise sub-paths) |
|             | \`article-missing-date-published\`      | error     | Required                                                   |
|             | \`article-bad-date-published\`          | warn      | Not ISO 8601                                               |
|             | \`article-bad-date-modified\`           | warn      | Not ISO 8601                                               |
|             | \`article-modified-before-published\`   | warn      | Common copy-paste bug                                      |
|             | \`article-missing-author\`              | warn      | Recommended                                                |
|             | \`article-missing-publisher\`           | info      | Recommended                                                |
| Breadcrumb  | \`breadcrumb-empty\`                    | warn      | No \`itemListElement\`                                       |
|             | \`breadcrumb-missing-position\`         | warn      | Per item                                                   |
|             | \`breadcrumb-missing-name\`             | warn      | Per item                                                   |
|             | \`breadcrumb-missing-item\`             | info      | Per item (final crumb may omit)                            |
|             | \`breadcrumb-bad-positions\`            | warn      | Positions aren't 1, 2, … N                                 |
| Cross-block | \`duplicate-id\`                        | warn      | Same \`@id\` in 2+ blocks (Google may merge or drop entities) |

The walker recurses into \`@graph\` (Yoast / Rank-Math style) and bare arrays so every inner entity gets its own checks. Each issue carries a precise dotted path like \`@graph[1].headline\` or \`itemListElement[2].item\`.

#### UI integration

- **Per-card severity badge** in the collapsed summary: red \`✕ N\` for errors, yellow \`! N\` for warnings, blue \`i N\` for notes.
- **Card border** turns red or yellow when issues are present.
- **Cards with errors auto-open** on first render so the user sees problems without an extra click.
- **Issues list** renders above the JSON pre when expanded, reusing the existing \`.cs-seo-issue\` tone classes from the page-level Issues section. Each row shows the message + the precise field path in monospace.
- **Section-level counters** in the header: \`3 blocks · ✕ 2 errors · ! 4 warnings\`.

### 3. Refactor + bonus bug fix (carried over from earlier in this PR)

- Extracted the JSON syntax-highlight regex from \`JsonPreview.tsx\` into a shared \`src/lib/json-highlight.ts\`.
- Fixed a latent regex bug that was making \`.cs-json-key\` dead code — every key in the JSON tab was rendering with the string color instead of the accent color. Now keys correctly highlight in both tabs.

## Test plan

- [x] \`npm run validate\` (typecheck + lint + format + 113 tests, +29 new across this PR)
- [x] \`npm run build\` clean
- [ ] On a Clay page with multiple JSON-LD blocks: open SEO tab → confirm a card renders for each block → click a card → JSON expands with syntax highlighting → click copy → toast confirms
- [ ] On a page with a JSON-LD block that's missing an Article \`headline\`: card auto-opens, summary shows red \`✕\` badge, expanded body lists the issue with path
- [ ] On a page with a malformed JSON-LD block: card shows \"Invalid JSON\" with red border and raw script contents
- [ ] On a page with no JSON-LD: \"Page basics\" still shows _none_, no JSON-LD section appears
- [ ] Keyboard: Tab to a card summary → Enter toggles open/closed
- [ ] JSON tab: keys (e.g. \`\"_ref\":\`) now render in the accent color, not green

## Files

- New: \`src/lib/json-highlight.ts\`, \`tests/lib/json-highlight.test.ts\`
- Updated: \`src/lib/seo.ts\` (\`summarizeJsonLd\` + \`lintJsonLd\` + types), \`src/content/panel/components/SeoTab.tsx\`, \`src/content/panel/components/JsonPreview.tsx\`, \`src/content/panel/styles.css\`, \`tests/lib/seo.test.ts\` (+25 tests)

## Commits

- \`f6a5f9a\` 🍕 feat(seo): collapsible JSON-LD viewer in the SEO tab
- \`accaa51\` 🍕 feat(seo): inline JSON-LD validator with per-block issues