### PR TITLE
🍕 chore(theme): unify accent on blue across panel + page + popup + badge

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -1,6 +1,11 @@
 import type { CaptureResponse, RuntimeMessage } from '@/lib/types';
 
-const BADGE_BG = '#e22c2c';
+// Toolbar badge color — matches the unified inspector accent
+// (`--cs-accent` in the panel theme, `ACCENT_RGB` in the highlighter).
+// Chrome doesn't switch theme on the badge, so we pick the lighter
+// blue-400 variant which stays readable against either a light or dark
+// browser-toolbar background.
+const BADGE_BG = '#60a5fa';
 const POPUP_PATH = 'src/popup/index.html';
 
 chrome.runtime.onInstalled.addListener(() => {

--- a/src/content/panel/theme.ts
+++ b/src/content/panel/theme.ts
@@ -26,8 +26,11 @@ export const lightTheme: ThemeTokens = {
   text: '#0f172a',
   textMuted: '#475569',
   textSubtle: '#94a3b8',
-  accent: '#e22c2c',
-  accentBg: 'rgba(226, 44, 44, 0.08)',
+  // Single inspector accent — matches `ACCENT_RGB` in `src/content/highlighter.ts`
+  // so the on-page selection outline and the in-panel selection chrome
+  // tell one consistent visual story. Tailwind blue-600.
+  accent: '#2563eb',
+  accentBg: 'rgba(37, 99, 235, 0.10)',
   success: '#16a34a',
   warning: '#d97706',
   danger: '#dc2626',
@@ -43,8 +46,10 @@ export const darkTheme: ThemeTokens = {
   text: '#e6e8ee',
   textMuted: '#9aa3b2',
   textSubtle: '#5f6776',
-  accent: '#ff5c5c',
-  accentBg: 'rgba(255, 92, 92, 0.12)',
+  // Lighter blue-400 in dark mode to keep WCAG AA contrast on dark backgrounds.
+  // Same hue family as light theme so the visual identity stays coherent.
+  accent: '#60a5fa',
+  accentBg: 'rgba(96, 165, 250, 0.16)',
   success: '#34d399',
   warning: '#fbbf24',
   danger: '#f87171',

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -5,7 +5,8 @@
   --text: #0f172a;
   --text-muted: #475569;
   --border: #e5e7eb;
-  --accent: #e22c2c;
+  /* Unified inspector accent — see src/content/panel/theme.ts. */
+  --accent: #2563eb;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -15,7 +16,7 @@
     --text: #e6e8ee;
     --text-muted: #9aa3b2;
     --border: #252a36;
-    --accent: #ff5c5c;
+    --accent: #60a5fa;
   }
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -47,9 +47,16 @@ body {
 .popup-link {
   display: inline-block;
   font-size: 12px;
-  color: #e22c2c;
+  /* Match the inspector accent everywhere else in the extension. */
+  color: #2563eb;
   text-decoration: none;
   font-weight: 500;
+}
+
+@media (prefers-color-scheme: dark) {
+  .popup-link {
+    color: #60a5fa;
+  }
 }
 
 .popup-link:hover {


### PR DESCRIPTION
## Why

Closes the visual disconnect introduced by the highlight-mode redesign (PR #11): the on-page outline switched to **tailwind blue-600**, but the panel kept the v1 **red** accent — so the same selection lit up blue on the page and red in the panel describing it.

Now every accent surface in the extension reads from one source of truth.

## Surfaces touched

| Surface              | Before                  | After                   |
| -------------------- | ----------------------- | ----------------------- |
| On-page outlines     | \`#2563eb\` (blue-600)    | \`#2563eb\` (no change)   |
| Panel light theme    | \`#e22c2c\` (red)         | \`#2563eb\`               |
| Panel dark theme     | \`#ff5c5c\` (red-light)   | \`#60a5fa\` (blue-400)    |
| Options light theme  | \`#e22c2c\`               | \`#2563eb\`               |
| Options dark theme   | \`#ff5c5c\`               | \`#60a5fa\`               |
| Popup link           | \`#e22c2c\` (no dark)     | \`#2563eb\` / \`#60a5fa\`   |
| Toolbar badge        | \`#e22c2c\`               | \`#60a5fa\`               |

Everything in the panel that uses \`var(--cs-accent)\` (FAB ring, FAB badge, breadcrumb chip, active-tab underline, primary buttons, tree/recents selection state, focus rings, mode-menu radio bullet, JSON-LD card open state, etc.) follows automatically.

## Why blue

- **Conventional inspector signal.** Chrome DevTools, React DevTools, Vue DevTools all use blue. Muscle memory works for free.
- **Editorial brands lean black/white/red.** Red outlines compete with content; blue stays out of the way.
- **The Clay character icon (beige/cream) is the brand mark.** The *accent* doesn't have to carry brand color and never reliably did.

## Why a different blue in dark mode

Blue-600 on a near-black background looks recessed and fails contrast against muted text. **Blue-400** is the same hue family but lifts to a comfortable ~4.7:1 ratio on \`#0f1115\`.

## Why the toolbar badge specifically picks blue-400

The browser toolbar isn't theme-aware (Chrome paints it grey on light OS, near-black on dark OS). Blue-600 disappears against dark toolbars; **blue-400 stays readable on both**.

## What didn't change

- \`--cs-success\` / \`--cs-warning\` / \`--cs-danger\` tokens stay green / amber / red. Status badges (Published / Draft), find-match outline, error toasts all unchanged.
- \`ACCENT_RGB\` in \`highlighter.ts\` is already blue-600 — kept as is.
- The Clay icon stays beige.
- No new files; all 137 tests pass.

## Test plan

- [x] \`npm run validate\` (typecheck + lint + format + 137 tests)
- [x] \`npm run build\` clean
- [ ] Reload unpacked extension on a Clay page → click any component
  - Page draws a **blue** outline + label badge (no change)
  - Panel breadcrumb chip is **blue** (was red)
  - Active-tab underline is **blue** (was red)
  - FAB component-count badge is **blue** (was red)
- [ ] Switch OS to dark mode → accents stay blue but lighter
- [ ] Open Options → accents are blue everywhere
- [ ] Open the popup on a Clay page → \"Allow / configure\" link is blue
- [ ] Verify Published/Draft badges (green/amber) and error toasts (red) are unchanged

Made with [Cursor](https://cursor.com)